### PR TITLE
Allow to pass `ref` to the icon

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,6 +2,7 @@
 import { FC, SVGAttributes } from 'react';
 
 interface Props extends SVGAttributes<SVGElement> {
+  ref?: SVGElement;
   color?: string;
   size?: string | number;
 }


### PR DESCRIPTION
Just a type fix