### PR TITLE
Update TypeScript props to include title

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,6 +4,7 @@ import { FC, SVGAttributes } from 'react';
 interface Props extends SVGAttributes<SVGElement> {
   color?: string;
   size?: string | number;
+  title?: string;
 }
 
 type Icon = FC<Props>;


### PR DESCRIPTION
It seems title is not in the TypeScript definition but is in the readme & in the JS file as a prop.