### PR TITLE
chore: update deprecated set-output commands

### DIFF
--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -29,7 +29,7 @@ jobs:
 
       # We use week in the turbo cache key to keep the cache from infinitely growing
       - id: get-week
-        run: echo ::set-output name=WEEK::$(date +%U)
+        run: echo name=WEEK::$(date +%U) >> $GITHUB_OUTPUT
 
       - name: Turbo Cache
         id: turbo-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
       # We use week in the turbo cache key to keep the cache from infinitely growing
       - id: get-week
-        run: echo ::set-output name=WEEK::$(date +%U)
+        run: echo name=WEEK::$(date +%U) >> $GITHUB_OUTPUT
 
       - name: Turbo Cache
         id: turbo-cache


### PR DESCRIPTION
Update GitHub Actions deprecated `set-output` command

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/