### PR TITLE
Change title to match SVG

### DIFF
--- a/.changeset/twelve-dogs-provide.md
+++ b/.changeset/twelve-dogs-provide.md
@@ -1,0 +1,5 @@
+---
+'@icons-pack/react-simple-icons': patch
+---
+
+Change title to match simpleicons svg titles

--- a/scripts/generate-components.js
+++ b/scripts/generate-components.js
@@ -41,7 +41,12 @@ Promise.all(
 
     return fsPromise.writeFile(
       componentFilePath,
-      iconFileTemplate(componentName, baseName, `#${simpleIcons[baseName].hex}`, simpleIcons[baseName].path),
+      iconFileTemplate(
+        componentName,
+        simpleIcons[baseName].title,
+        `#${simpleIcons[baseName].hex}`,
+        simpleIcons[baseName].path,
+      ),
       formatFile,
     );
   }),

--- a/scripts/templates.js
+++ b/scripts/templates.js
@@ -2,13 +2,13 @@
 This icon component file as `src/components/[componentName].ts`.
 */
 const iconFileTemplate = (componentName, baseName, hex, path) => `import baseIcon from '../base';
-const ${componentName} = baseIcon('${baseName}', '${hex}', '${path}');
+const ${componentName} = baseIcon("${baseName}", '${hex}', '${path}');
 export default ${componentName};\n`;
 
 /**
 The single line for exporting component in `src/index.ts`.
 */
-const iconExportTemplate = componentName =>
+const iconExportTemplate = (componentName) =>
   `export { default as ${componentName} } from './components/${componentName}';`;
 
 /**
@@ -25,7 +25,7 @@ type I = IconType;\n`;
 /**
 The single line for exporting component declaration in `dist/index.d.ts`
 */
-const iconDeclarationExportTemplate = componentName => `export const ${componentName}: I;`;
+const iconDeclarationExportTemplate = (componentName) => `export const ${componentName}: I;`;
 
 module.exports = {
   iconFileTemplate,


### PR DESCRIPTION
This changes from using the `baseName` to the title exported from `simple-icons`, making the `<title>`s in the React components match the underlying SVGs, rather than having the si prefix