### PR TITLE
fix: export everything in package.json

### DIFF
--- a/.changeset/hungry-olives-stare.md
+++ b/.changeset/hungry-olives-stare.md
@@ -1,0 +1,5 @@
+---
+'@icons-pack/react-simple-icons': patch
+---
+
+Declare all exported files in package.json

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
       "require": "./index.cjs"
     },
     "./package.json": "./package.json",
-    "./icons/*": "./icons/*",
+    "./icons/*": "./icons/*"
   },
   "sideEffects": false,
   "files": [

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
       "import": "./index.mjs",
       "require": "./index.cjs"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./icons/*": "./icons/*",
   },
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
Right now it's not possible to import icons directly (when using RollupJS) because `icons` folder is not exposed to resolver

Example this will fail:
```ts
const Si1001tracklists = import('@icons-pack/react-simple-icons/icons/Si1001tracklists');
```
Fail with rollup : https://codesandbox.io/p/github/codesandbox/codesandbox-template-vite-react/csb-8yft4m/draft/tender-tristan?file=/src/App.tsx:8,1
Work with webpack https://codesandbox.io/s/magical-rain-7hjvwk?file=/src/App.tsx

This simple change should do the tricks (tested locally by modifying the package.json in my project)