### PR TITLE
docs(README.md): fix typo & badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,8 @@ This package provides the [Simple Icons 15.7.0](https://github.com/simple-icons/
 packaged as a set of [React](https://facebook.github.io/react/) components.
 
   <a href="https://www.npmjs.com/package/@icons-pack/react-simple-icons" target="_blank"><img src="https://img.shields.io/npm/v/@icons-pack/react-simple-icons?color=CB061D&style=flat-square" alt="www.npmjs.com!" /></a>
-
   <a href="https://dependents.info/icons-pack/react-simple-icons" target="_blank"><img src="https://dependents.info/icons-pack/react-simple-icons/badge?label=users&color=087BB4&style=flat-square" alt="network dependents" /></a>
-
   <a href="https://www.npmjs.com/package/@icons-pack/react-simple-icons" target="_blank"><img src="https://img.shields.io/npm/dw/@icons-pack/react-simple-icons?color=087BB4&style=flat-square" alt="downloads" /></a>
-
   <a href="https://github.com/icons-pack/react-simple-icons/blob/canary/LICENSE" target="_blank"><img src="https://img.shields.io/npm/l/@icons-pack/react-simple-icons?color=008660&style=flat-square" alt="licence" /></a>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ This package provides the [Simple Icons 15.7.0](https://github.com/simple-icons/
 packaged as a set of [React](https://facebook.github.io/react/) components.
 
   <a href="https://www.npmjs.com/package/@icons-pack/react-simple-icons" target="_blank"><img src="https://img.shields.io/npm/v/@icons-pack/react-simple-icons?color=CB061D&style=flat-square" alt="www.npmjs.com!" /></a>
-  <a href="https://dependents.info/icons-pack/react-simple-icons" target="_blank"><img src="https://dependents.info/icons-pack/react-simple-icons/badge?label=users&color=087BB4&style=flat-square" alt="network dependents" /></a>
   <a href="https://www.npmjs.com/package/@icons-pack/react-simple-icons" target="_blank"><img src="https://img.shields.io/npm/dw/@icons-pack/react-simple-icons?color=087BB4&style=flat-square" alt="downloads" /></a>
   <a href="https://github.com/icons-pack/react-simple-icons/blob/canary/LICENSE" target="_blank"><img src="https://img.shields.io/npm/l/@icons-pack/react-simple-icons?color=008660&style=flat-square" alt="licence" /></a>
 </div>

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 This package provides the [Simple Icons 15.7.0](https://github.com/simple-icons/simple-icons/releases/tag/15.7.0)
 packaged as a set of [React](https://facebook.github.io/react/) components.
 
-  <a href="https://www.npmjs.com/package/@icons-pack/react-simple-icons" target="_blank"><img src="https://img.shields.io/npm/v/@icons-pack/react-simple-icons?color=CB061D&style=flat-square" alt="www.npmjs.com!" /></a>
-  <a href="https://www.npmjs.com/package/@icons-pack/react-simple-icons" target="_blank"><img src="https://img.shields.io/npm/dw/@icons-pack/react-simple-icons?color=087BB4&style=flat-square" alt="downloads" /></a>
-  <a href="https://github.com/icons-pack/react-simple-icons/blob/canary/LICENSE" target="_blank"><img src="https://img.shields.io/npm/l/@icons-pack/react-simple-icons?color=008660&style=flat-square" alt="licence" /></a>
+  [![www.npmjs.com!](https://img.shields.io/npm/v/@icons-pack/react-simple-icons?color=CB061D&style=flat-square)](https://www.npmjs.com/package/@icons-pack/react-simple-icons)
+  [![downloads](https://img.shields.io/npm/dw/@icons-pack/react-simple-icons?color=087BB4&style=flat-square)](https://www.npmjs.com/package/@icons-pack/react-simple-icons)
+  [![license](https://img.shields.io/npm/l/@icons-pack/react-simple-icons?color=008660&style=flat-square)](https://github.com/icons-pack/react-simple-icons/blob/main/LICENSE)
 </div>
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -6,20 +6,16 @@
 This package provides the [Simple Icons 15.7.0](https://github.com/simple-icons/simple-icons/releases/tag/15.7.0)
 packaged as a set of [React](https://facebook.github.io/react/) components.
 
-  <a href="https://www.npmjs.com/package/@icons-pack/react-simple-icons" target="_blank">
-    <img src="https://img.shields.io/npm/v/@icons-pack/react-simple-icons?color=CB061D&style=flat-square" alt="www.npmjs.com!" />
-  </a>
+  <a href="https://www.npmjs.com/package/@icons-pack/react-simple-icons" target="_blank"><img src="https://img.shields.io/npm/v/@icons-pack/react-simple-icons?color=CB061D&style=flat-square" alt="www.npmjs.com!" /></a>
 
-  <a href="https://www.npmjs.com/package/@icons-pack/react-simple-icons" target="_blank">
-    <img src="https://img.shields.io/npm/dw/@icons-pack/react-simple-icons?color=087BB4&style=flat-square" alt="downloads" />
-  </a>
+  <a href="https://dependents.info/icons-pack/react-simple-icons" target="_blank"><img src="https://dependents.info/icons-pack/react-simple-icons/badge?label=users&color=087BB4&style=flat-square" alt="network dependents" /></a>
 
-  <a href="https://github.com/icons-pack/react-simple-icons/blob/canary/LICENSE" target="_blank">
-    <img src="https://img.shields.io/npm/l/@icons-pack/react-simple-icons?color=008660&style=flat-square" alt="licence" />
-  </a>
+  <a href="https://www.npmjs.com/package/@icons-pack/react-simple-icons" target="_blank"><img src="https://img.shields.io/npm/dw/@icons-pack/react-simple-icons?color=087BB4&style=flat-square" alt="downloads" /></a>
+
+  <a href="https://github.com/icons-pack/react-simple-icons/blob/canary/LICENSE" target="_blank"><img src="https://img.shields.io/npm/l/@icons-pack/react-simple-icons?color=008660&style=flat-square" alt="licence" /></a>
 </div>
 
-## Inestallation
+## Installation
 
 Install the package in your project directory with:
 


### PR DESCRIPTION
Hi there,

Thanks for the awesome project! This PR

- fixes a typo in the readme
- removes unnecessary link underline line on the badges (as per [this](https://github.com/orgs/community/discussions/79043#discussioncomment-7990622)).

  <img width="250" height="34" alt="image" src="https://github.com/user-attachments/assets/463f92eb-07b5-469f-84d8-67266ad4e87e" />

- adds a relevant users badge using an [open source](https://github.com/gouravkhunger/dependents.info) tool I built some time ago and plan to maintain for long.
  
  <img width="400" height="55" alt="image" src="https://github.com/user-attachments/assets/7d903dca-c62c-4025-8a01-3090a0cc5836" />

a users preview is also possible but that requires additional setup, do lmk if you'd like to see that, I can update the PR. [Here](https://github.com/xandemon/developer-icons)'s a repo already using it. Preview for yours:

<img width="707" height="158" alt="image" src="https://github.com/user-attachments/assets/9011e159-f466-496b-bfce-e37cc8107462" />

Thanks!